### PR TITLE
chore: change item data url

### DIFF
--- a/shared/src/commonMain/kotlin/com/maderskitech/kmpcodingexercisenetwork/data/remote/api/ItemsApiImpl.kt
+++ b/shared/src/commonMain/kotlin/com/maderskitech/kmpcodingexercisenetwork/data/remote/api/ItemsApiImpl.kt
@@ -7,7 +7,11 @@ import com.maderskitech.kmpcodingexercisenetwork.platform.NetworkClient
 import com.maderskitech.kmpcodingexercisenetwork.testingsupport.OpenForMokkery
 import io.ktor.client.call.body
 import io.ktor.client.request.get
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.withCharset
 import io.ktor.util.network.UnresolvedAddressException
+import io.ktor.utils.io.charsets.Charsets
 import kotlinx.serialization.SerializationException
 
 /**
@@ -28,7 +32,7 @@ class ItemsApiImpl(private val networkClient: NetworkClient) : ItemsApi{
     override suspend fun getItems(): Response<List<ItemDto?>?, NetworkError> {
         val response = try {
             networkClient.httpClient.get(
-                urlString = "https://fetch-hiring.s3.amazonaws.com/hiring.json"
+                urlString = ITEMS_URL
             )
         } catch (e: UnresolvedAddressException) {
             return Response.Failure(NetworkError.NO_INTERNET)
@@ -50,5 +54,9 @@ class ItemsApiImpl(private val networkClient: NetworkClient) : ItemsApi{
             in 500 .. 599 -> Response.Failure(NetworkError.SERVER_ERROR)
             else -> Response.Failure(NetworkError.UNKNOWN)
         }
+    }
+
+    companion object {
+        private const val ITEMS_URL = "https://raw.githubusercontent.com/maderski/coding-exercise-data/main/items.json"
     }
 }

--- a/shared/src/commonMain/kotlin/com/maderskitech/kmpcodingexercisenetwork/data/remote/api/network/HttpClientFactory.kt
+++ b/shared/src/commonMain/kotlin/com/maderskitech/kmpcodingexercisenetwork/data/remote/api/network/HttpClientFactory.kt
@@ -5,7 +5,10 @@ import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
+import io.ktor.http.ContentType
+import io.ktor.http.withCharset
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.charsets.Charsets
 import kotlinx.serialization.json.Json
 
 /**
@@ -18,18 +21,20 @@ object HttpClientFactory {
             level = LogLevel.ALL
         }
         install(ContentNegotiation) {
-            json(
-                json = Json {
-                    isLenient = true
+            val jsonConfig = Json {
+                isLenient = true
 
-                    /*
-                    If the API responds with client fields that our client doesn't know about
-                    because we didn't define it in our model, don't crash the app and ignore these
-                    fields.
-                     */
-                    ignoreUnknownKeys = true
-                }
-            )
+                /*
+                If the API responds with client fields that our client doesn't know about
+                because we didn't define it in our model, don't crash the app and ignore these
+                fields.
+                 */
+                ignoreUnknownKeys = true
+            }
+            // Accept real JSON
+            json(jsonConfig, ContentType.Application.Json)
+            // Accept GitHub’s text/plain variant
+            json(jsonConfig, ContentType.Text.Plain.withCharset(Charsets.UTF_8))
         }
     }
 }


### PR DESCRIPTION
## Description
Changes the url to get the item data from and update the HttpClientFactory to also accept Github's text/plain variant

## Receipt
Verified with quick test call in library to verify data is still being pulled down.
```
Success(data=[ItemDto(id=755, listId=2, name=), ItemDto(id=203, listId=2, name=), ItemDto(id=684, listId=1, name=Item 684), ItemDto(id=276, listId=1, name=Item 276),...
```